### PR TITLE
Using manager runnable

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,11 +107,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (rbac.RBACManager{
-		ClientConfig: mgr.GetConfig(),
+	rbacMngr := &rbac.Manager{
 		CapsuleGroup: capsuleGroup,
-		Log:          setupLog,
-	}).SetupCapsuleRoles(); err != nil {
+		Log:          ctrl.Log.WithName("controllers").WithName("Rbac"),
+	}
+	err = mgr.Add(rbacMngr)
+	if err != nil {
 		setupLog.Error(err, "unable to create cluster roles")
 		os.Exit(1)
 	}


### PR DESCRIPTION
The RBAC Manager is really good but we faced an issue: running that sort of reconciliation before the Manager could start since, otherwise, the `client.Client` wasn't able to retrieve resources.

I noticed that the Manager can add a `Runnable` interface, so decided to give it a try, and here's the PR to improve yours.

I guess this could be used as base to implement also a `Reconciler` interface using Predicates to work only on the requested resources: just need to decouple all the business logic from `Start` to specific _funcs_.